### PR TITLE
Ajout d'une tooltip CSS pour chaque icône

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,6 +33,7 @@ strong {
 
 .part li {
     display: inline-block;
+    position: relative;
     list-style-type: none;
     margin-left: 5px;
 }
@@ -50,17 +51,60 @@ strong {
 .small_cat li img {
     max-width: 35px;
     max-height: 35px;
+    min-height: 35px;
 }
 
 .part li a {
     border-radius: 100%;
     display: table-cell;
     text-align: center;
+    text-decoration: none;
     width: 55px;
 }
 
-
-.part li a:focus, .part li a:hover {
+.part li a:focus img, .part li a:hover img {
     opacity: 0.7;
     outline: medium none;
+}
+
+.tooltip {
+    display: block;
+    position: absolute;
+        bottom: -45px; right: -9px;
+    padding: .25em .5em;
+    background-color: #fcfcfc;
+    border-radius: .2rem;
+    color: #252525;
+    opacity: 0;
+    -webkit-transition: opacity .5s ease;
+    transition: opacity .5s ease;
+    white-space: nowrap;
+}
+
+.tooltip::after {
+    display: block;
+    position: absolute;
+        top: -5px; right: 32px;
+    height: .6rem;
+    width: .6rem;
+    content: '';
+    background: #fcfcfc;
+    -webkit-transform: rotate(45deg);
+            transform: rotate(45deg);
+}
+
+.part li:nth-of-type(-n + 2) a .tooltip {
+    left: -9px;
+    right: auto;
+}
+
+.part li:nth-of-type(-n + 2) a .tooltip::after {
+    left: 32px;
+    right: auto;
+}
+
+@media all and (min-width: 480px) {
+  .part li a:focus .tooltip, .part li a:hover .tooltip {
+      opacity: .85;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <title>Pierre Rudloff</title>
         <link rel="stylesheet" href="dist/main.css" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
         <link rel="icon" href="images/favicon.png" />
     </head>
     <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
         <link rel="stylesheet" href="dist/main.css" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="images/favicon.png" />
-        <meta name="description" content="Développeur + associatif + formateur" />
     </head>
     <body>
         <h1>
@@ -16,24 +15,24 @@
         <div class="cat small_cat">
             <h2>Mon travail</h2>
             <ul class="part">
-                <li><a href="http://www.animafac.net/" title="Animafac" target="_blank"><img src="images/logo_animafac.png" alt="Animafac" /></a></li>
+                <li><a href="http://www.animafac.net/" title="Animafac" target="_blank"><img src="images/logo_animafac.png" alt="Animafac" /><span class="tooltip" aria-hidden="true">Animafac</span></a></li>
             </ul>
         </div>
         <div class="cat">
             <h2>Mes projets</h2>
             <ul class="part">
-                <li><a href="https://strasweb.fr/" title="StrasWeb" target="_blank"><img src="images/logo_strasweb.svg" alt="StrasWeb" /></a></li>
-                <li><a href="https://shakepeers.org/Accueil" title="ShakePeers" target="_blank"><img src="images/logo_shakepeers.svg" alt="ShakePeers" /></a></li>
-                <li><a href="https://quai10.org/" title="Quai n°10" target="_blank"><img src="images/logo_quai10.svg" alt="Quai n°10" /></a></li>
-                <li><a href="https://alltube.herokuapp.com/" title="AllTube Download" target="_blank"><img src="images/logo_alltube.png" alt="AllTube Download" /></a></li>
+                <li><a href="https://strasweb.fr/" title="StrasWeb" target="_blank"><img src="images/logo_strasweb.svg" alt="StrasWeb" /><span class="tooltip" aria-hidden="true">StrasWeb</span></a></li>
+                <li><a href="https://shakepeers.org/Accueil" title="ShakePeers" target="_blank"><img src="images/logo_shakepeers.svg" alt="ShakePeers" /><span class="tooltip" aria-hidden="true">ShakePeers</span></a></li>
+                <li><a href="https://quai10.org/" title="Quai n°10" target="_blank"><img src="images/logo_quai10.svg" alt="Quai n°10" /><span class="tooltip" aria-hidden="true">Quai n°10</span></a></li>
+                <li><a href="https://alltube.herokuapp.com/" title="AllTube Download" target="_blank"><img src="images/logo_alltube.png" alt="AllTube Download" /><span class="tooltip" aria-hidden="true">AllTube Download</span></a></li>
             </ul>
         </div>
         <div class="cat">
             <h2>Me trouver</h2>
             <ul class="part small_cat">
-                <li><a href="https://github.com/Rudloff" title="Sur GitHub" target="_blank"><img src="images/logo_github.svg" alt="Sur GitHub" /></a></li>
-                <li><a href="https://twitter.com/Tael67" title="Sur Twitter" target="_blank"><img src="images/logo_twitter.svg" alt="Sur Twitter" /></a></li>
-                <li><a href="mailto:contact@rudloff.pro" title="Par mail" target="_blank"><img src="images/logo_mail.svg" alt="Par mail" /></a></li>
+                <li><a href="https://github.com/Rudloff" title="Sur GitHub" target="_blank"><img src="images/logo_github.svg" alt="Sur GitHub" /><span class="tooltip" aria-hidden="true">Sur GitHub</span></a></li>
+                <li><a href="https://twitter.com/Tael67" title="Sur Twitter" target="_blank"><img src="images/logo_twitter.svg" alt="Sur Twitter" /><span class="tooltip" aria-hidden="true">Sur Twitter</span></a></li>
+                <li><a href="mailto:contact@rudloff.pro" title="Par mail" target="_blank"><img src="images/logo_mail.svg" alt="Par mail" /><span class="tooltip" aria-hidden="true">Par mail</span></a></li>
             </ul>
         </div>
     </body>


### PR DESCRIPTION
Ajout d'une petite et simple tooltip CSS pour chaque icône sur cette page statique.

Tests effectués sous Firefox 43, Chrome 48, Safari 9 (Mac OS 10.11.3) :smile_cat: 
